### PR TITLE
Support Rails 7.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         gemfile:
           - gemfiles/Gemfile.rails61
           - gemfiles/Gemfile.rails70
+          - gemfiles/Gemfile.rails71
         exclude:
           # rails 7.0 requires ruby >= 2.7
           # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-* No unreleased changes
+* Support Rails 7.1
 
 ## 5.9.4 / 2023-07-13
 ### Added

--- a/gemfiles/Gemfile.rails52
+++ b/gemfiles/Gemfile.rails52
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'activerecord',  '~> 5.2.0'
-gem 'activesupport', '~> 5.2.0'

--- a/gemfiles/Gemfile.rails71
+++ b/gemfiles/Gemfile.rails71
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activerecord',  '~> 7.1.0'
+gem 'activesupport', '~> 7.1.0'

--- a/ndr_support.gemspec
+++ b/ndr_support.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord',  '>= 6.1', '< 7.1'
-  spec.add_dependency 'activesupport', '>= 6.1', '< 7.1'
+  spec.add_dependency 'activerecord',  '>= 6.1', '< 7.2'
+  spec.add_dependency 'activesupport', '>= 6.1', '< 7.2'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '>= 12.3.3'


### PR DESCRIPTION
Support Rails 7.1 in `ndr_support`.

The tests currently produce a few deprecation warnings on Rails 7.1. This is expected behaviour [and the deprecations are triggered only by the tests, not the main `ndr_support` code], which we cannot resolve cleanly until we drop support for Rails 6.1.