### PR TITLE
YAMLSupport should preserve escape sequences in JSON text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-* No unreleased changes
+## Fixed
+* YAMLSupport should preserve escape sequences in JSON text
 
 ## 5.9.5 / 2023-10-26
 * Support Rails 7.1

--- a/lib/ndr_support/yaml/serialization_migration.rb
+++ b/lib/ndr_support/yaml/serialization_migration.rb
@@ -57,6 +57,9 @@ module NdrSupport
       # While `psych` emits UTF-8 YAML, `syck` double escapes
       # higher characters. We need to unescape any we find:
       def handle_special_characters!(string, coerce_invalid_chars)
+        # TODO: Change to only handle syck control characters
+        return unless string.start_with?('---') # Only handle YAML that is not JSON
+
         # Replace any encoded hex chars with their actual value:
         string.gsub!(/((?:\\x[0-9A-F]{2})+)/) do
           byte_sequence = $1.scan(/[0-9A-F]{2}/)

--- a/test/yaml/serialization_test.rb
+++ b/test/yaml/serialization_test.rb
@@ -29,6 +29,11 @@ class SerializationTest < Minitest::Test
     assert_equal "control 0x01 char \n whoops!", load_yaml(chr_1_yaml)
   end
 
+  test 'should leave non-binary JSON with things that look like control chars unchanged' do
+    hash = { 'report' => ' \x09 ' }
+    assert_equal hash, load_yaml(hash.to_json)
+  end
+
   test 'load_yaml should not coerce to UTF-8 by default' do
     assert_yaml_coercion_behaviour
   end


### PR DESCRIPTION
Our support for historical syck YAML is unintentionally converting control sequences in JSON data into control characters. For example, the clean ASCII string `' \x09 '` [space][backslash][x][0][9][space] is being converted into [space][tab][space].

We really need to fix this better, to also not transform psych YAML in this way, but that needs further work, and may affect other code, so may need a minor / major `ndr_support` version bump.

This fix should affect only JSON data, so should be safe for a minor bump.

Related tickets: https://ncr.plan.io/issues/2410 and https://nhsd-jira.digital.nhs.uk/browse/NDRS2-113 and https://ncr.plan.io/issues/34564