### PR TITLE
Move to UTF-8 encode YAML and support YAML.safe_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
-* No unreleased changes
+## Changed
+* Generate UTF-8 encoded YAML by default. Disable with `utf8_storage = false`
+* Use `YAML.safe_load` by default. Override with
+  `self.yaml_safe_classes = yaml_safe_classes + [Klass1, Klass2]` and revert to
+  unsafe loading with `yaml_safe_classes = :unsafe` and `gem 'psych', '< 4'`
 
 ## 5.9.7 / 2023-11-16
 ## Fixed


### PR DESCRIPTION
* Generate UTF-8 encoded YAML by default. Disable with `utf8_storage = false`

* Use `YAML.safe_load` by default. Override with `self.yaml_safe_classes = yaml_safe_classes + [Klass1, Klass2]` and revert to unsafe loading with `yaml_safe_classes = :unsafe`

These changes will be major version bump, but the old behaviour can be restored if necessary with a feature flag. This is a necessary step towards https://ncr.plan.io/issues/29615, identifying which classes we've embedded in our YAML and adding them to the safe list for encore.

I've just realised that we’re still generating base64 encoded text for YAML (in `!binary` blocks) for high UTF-8 characters. This PR allows us to turn that off and generate UTF-8 YAML.