### PR TITLE
Allow YAML aliases when using `yaml_safe_classes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-* No unreleased changes
+## Fixed
+* Allow YAML aliases when using `yaml_safe_classes`
 
 ## 5.10.0 / 2023-11-17
 ## Changed

--- a/lib/ndr_support/yaml/serialization_migration.rb
+++ b/lib/ndr_support/yaml/serialization_migration.rb
@@ -43,13 +43,11 @@ module NdrSupport
 
         # TODO: Bump NdrSupport major version, and switch to safe_load by default
         object = if yaml_safe_classes == :unsafe
-                   unless Psych::VERSION.start_with?('3.')
-                     raise(SecurityError, 'Unsafe YAML no longer supported')
-                   end
+                   raise(SecurityError, 'Unsafe YAML no longer supported') unless Psych::VERSION.start_with?('3.')
 
                    Psych.load(string)
                  else
-                   Psych.safe_load(string, permitted_classes: yaml_safe_classes)
+                   Psych.safe_load(string, permitted_classes: yaml_safe_classes, aliases: true)
                  end
 
         # Ensure that any string related to the object

--- a/test/yaml/serialization_test.rb
+++ b/test/yaml/serialization_test.rb
@@ -8,6 +8,14 @@ class SerializationTest < Minitest::Test
     assert_equal hash, load_yaml(dump_yaml(hash))
   end
 
+  test 'should support aliases correctly' do
+    x = { 'c' => 5 }
+    hash = { 'a' => x, 'b' => x }
+    hash_yaml = "---\na: &1\n  c: 5\nb: *1\n"
+    assert_equal hash, load_yaml(hash_yaml), 'Deserialising known YAML with an alias'
+    assert_equal hash, load_yaml(dump_yaml(hash)), 'Deserialising a structure with repeated objects'
+  end
+
   test 'should handle syck-encoded characters' do
     assert_syck_1_8_yaml_loads_correctly
   end


### PR DESCRIPTION
We need to allow aliases in our YAML parsing.

The standard YAML emitter will introduce aliases in its output if there are repeated references in nested structures. Some of these are unavoidable, e.g. multiple references to the same date object. Sample YAML (observed in practice) might contain something like:
```yaml
attendances:
- appointmentdate: &1 !ruby/object:DateTime 2023-01-01 00:00:00.000000000 Z
  appointmenttime: '11:15:00'
- appointmentdate: *1
  appointmenttime: '11:15:00'
```