### PR TITLE
Fix bug in roman5 cleaning (Relates ro  #ndrs2 711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
-* No unreleased changes
+## Fixed
+* Fixed issue with constant in wrone file/concern
+* Added tests for roman5 cleaning method
+* Seperated log10 tests
 
 ## 5.10.2 / 2024-02-09
 ## Fixed

--- a/lib/ndr_support/string/clean_methodable.rb
+++ b/lib/ndr_support/string/clean_methodable.rb
@@ -3,7 +3,7 @@
 module CleanMethodable
   extend ActiveSupport::Concern
 
-  ROMAN_ONE_TO_FIVE_MAPPING = { 'I' => '1', 'II' => '2', 'III' => '3', 'IIII' => '4', 'IV' => '4', 'V' => '5' }
+  ROMAN_ONE_TO_FIVE_MAPPING = { 'I' => '1', 'II' => '2', 'III' => '3', 'IIII' => '4', 'IV' => '4', 'V' => '5' }.freeze
 
   CLEAN_METHODS = {
     nhsnumber: :clean_nhsnumber,

--- a/lib/ndr_support/string/clean_methodable.rb
+++ b/lib/ndr_support/string/clean_methodable.rb
@@ -3,6 +3,8 @@
 module CleanMethodable
   extend ActiveSupport::Concern
 
+  ROMAN_ONE_TO_FIVE_MAPPING = { 'I' => '1', 'II' => '2', 'III' => '3', 'IIII' => '4', 'IV' => '4', 'V' => '5' }
+
   CLEAN_METHODS = {
     nhsnumber: :clean_nhsnumber,
     postcode: :clean_postcode, get_postcode: :clean_postcode,

--- a/lib/ndr_support/string/cleaning.rb
+++ b/lib/ndr_support/string/cleaning.rb
@@ -7,7 +7,6 @@ class String
   include CleanMethodable
 
   INVALID_CONTROL_CHARS = /[\x00-\x08\x0b-\x0c\x0e-\x1f]/
-  ROMAN_ONE_TO_FIVE_MAPPING = { 'I' => '1', 'II' => '2', 'III' => '3', 'IIII' => '4', 'IV' => '4', 'V' => '5' }
 
   POSTCODE_REGEXP = /
     ^(

--- a/test/string/cleaning_test.rb
+++ b/test/string/cleaning_test.rb
@@ -30,12 +30,25 @@ class String
       assert_equal 'IP222', 'IP222'.postcodeize(:db)
       assert_equal 'IP222E', 'IP222E'.postcodeize(:db)
       assert_equal 'HANTS', 'HANTS'.postcodeize(:db)
-      # Log10
+    end
+
+    test 'clean_log10' do
       assert_equal '0.0', '0'.clean(:log10)
       assert_equal '-10.1', '-10.1'.clean(:log10)
       assert_match(/\A0.041392685158225[0-9]*\z/, '1.1'.clean(:log10),
                    "Different ruby versions give '0.04139268515822507' or '0.04139268515822508'")
       assert_equal 'BILBO', 'BILBO'.clean(:log10)
+    end
+
+    test 'clean_roman5' do
+      assert_equal '12345', 'I2345'.clean(:roman5)
+      assert_equal '12345', '1II345'.clean(:roman5)
+      assert_equal '12345', '12III45'.clean(:roman5)
+      assert_equal '12345', '123IIII5'.clean(:roman5)
+      assert_equal '12345', '123IIII5'.clean(:roman5)
+      assert_equal '12345', '123IV5'.clean(:roman5)
+      assert_equal '12345', '1234V'.clean(:roman5)
+      assert_equal '12345', '1II34V'.clean(:roman5)
     end
 
     test 'xml_unsafe?' do


### PR DESCRIPTION
A bug was introcuced to the 'roman5' cleaning method due to the code clean up, but as there was no existing test coverage it was not spotted. So; Moved the Romand 1-2 constant to the new concern.  Added tests for the roman5 cleaning. Split the new log10 tests to their own method.