### PR TITLE
Support Rails 7.1, 7.2, 8.0, Ruby 3.2, 3.3. Drop support for Rails 6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,23 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
         gemfile:
-          - gemfiles/Gemfile.rails61
           - gemfiles/Gemfile.rails70
           - gemfiles/Gemfile.rails71
+          - gemfiles/Gemfile.rails72
+          - gemfiles/Gemfile.rails80
         exclude:
-          # rails 7.0 requires ruby >= 2.7
+          # rails 7.2 requires ruby >= 3.1
           # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
-          - ruby-version: '2.6'
-            gemfile: 'gemfiles/Gemfile.rails70'
+          - ruby-version: '3.0'
+            gemfile: 'gemfiles/Gemfile.rails72'
+          # rails 8.0 requires ruby >= 3.2
+          # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
+          - ruby-version: '3.0'
+            gemfile: 'gemfiles/Gemfile.rails80'
+          - ruby-version: '3.1'
+            gemfile: 'gemfiles/Gemfile.rails80'
 
     name: Ruby ${{ matrix.ruby-version }} / Bundle ${{ matrix.gemfile }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-* no unreleased changes
+### Added
+* Support Rails 7.1, 7.2, 8.0, Ruby 3.2, 3.3. Drop support for Rails 6.1
 
 ## 5.10.3 / 2023-02-12
 ## Fixed

--- a/gemfiles/Gemfile.rails61
+++ b/gemfiles/Gemfile.rails61
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'activerecord',  '~> 6.1.0'
-gem 'activesupport', '~> 6.1.0'

--- a/gemfiles/Gemfile.rails72
+++ b/gemfiles/Gemfile.rails72
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activerecord',  '~> 7.2.0'
+gem 'activesupport', '~> 7.2.0'

--- a/gemfiles/Gemfile.rails80
+++ b/gemfiles/Gemfile.rails80
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activerecord',  '~> 8.0.0'
+gem 'activesupport', '~> 8.0.0'

--- a/lib/ndr_support/ourdate.rb
+++ b/lib/ndr_support/ourdate.rb
@@ -15,11 +15,7 @@ class Ourdate
     #--
     # TODO: Use Ourdate.build_datetime everywhere below:
     #++
-    default_timezone = if ActiveRecord.respond_to?(:default_timezone)
-                         ActiveRecord.default_timezone
-                       else
-                         ActiveRecord::Base.default_timezone # Rails <= 6.1
-                       end
+    default_timezone = ActiveRecord.default_timezone
     if default_timezone == :local
       build_datetime(current_time.year, current_time.month, current_time.day)
     else

--- a/lib/ndr_support/ourdate/build_datetime.rb
+++ b/lib/ndr_support/ourdate/build_datetime.rb
@@ -10,11 +10,7 @@ class Ourdate
   def self.build_datetime(year, month = 1, day = 1, hour = 0, min = 0, sec = 0, usec = 0)
     return nil if year.nil?
 
-    default_timezone = if ActiveRecord.respond_to?(:default_timezone)
-                         ActiveRecord.default_timezone
-                       else
-                         ActiveRecord::Base.default_timezone # Rails <= 6.1
-                       end
+    default_timezone = ActiveRecord.default_timezone
     if default_timezone == :local
       # Time.local_time(year, month, day, hour, min, sec, usec).to_datetime
       # Behave like oracle_adapter.rb

--- a/lib/ndr_support/string/conversions.rb
+++ b/lib/ndr_support/string/conversions.rb
@@ -129,11 +129,7 @@ class String
 
   def to_datetime
     # Default timezone for to_datetime conversion is GMT, not local timezone
-    default_timezone = if ActiveRecord.respond_to?(:default_timezone)
-                         ActiveRecord.default_timezone
-                       else
-                         ActiveRecord::Base.default_timezone # Rails <= 6.1
-                       end
+    default_timezone = ActiveRecord.default_timezone
     return to_time.to_datetime if default_timezone == :local
 
     orig_to_datetime

--- a/ndr_support.gemspec
+++ b/ndr_support.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord',  '>= 6.1', '< 7.2'
-  spec.add_dependency 'activesupport', '>= 6.1', '< 7.2'
+  spec.add_dependency 'activerecord',  '>= 7.0', '< 8.1'
+  spec.add_dependency 'activesupport', '>= 7.0', '< 8.1'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '>= 12.3.3'

--- a/test/date_and_time_extensions_test.rb
+++ b/test/date_and_time_extensions_test.rb
@@ -6,7 +6,11 @@ require 'test_helper'
 class DateAndTimeExtensionsTest < Minitest::Test
   def test_date_to_s
     d = Date.new(2000, 2, 1)
-    assert_equal '2000-02-01', d.to_default_s, 'Rails 7 default to_s'
+    if d.respond_to?(:to_default_s) # Only defined on Rails <= 7.1
+      assert_equal '2000-02-01', d.to_default_s, 'Rails 7 default to_s'
+    else
+      assert_equal '2000-02-01', d.orig_to_s, 'Rails 7 default to_s (via our shim)'
+    end
     assert_equal '01.02.2000', d.to_formatted_s(:default), 'Rails 6 default to_s'
     assert_equal d.to_formatted_s(:default), d.to_s,
                  'We plan to change default to_s behaviour in a major version bump'
@@ -14,20 +18,33 @@ class DateAndTimeExtensionsTest < Minitest::Test
 
   def test_datetime_to_s
     bst_datetime = DateTime.new(2014, 4, 1, 0, 0, 0, '+1')
-    assert_equal '2014-04-01T00:00:00+01:00', bst_datetime.to_default_s, 'Rails 7 default to_s'
+    if bst_datetime.respond_to?(:to_default_s) # Only defined on Rails <= 7.1
+      assert_equal '2014-04-01T00:00:00+01:00', bst_datetime.to_default_s, 'Rails 7 default to_s'
+    else
+      assert_equal '2014-04-01T00:00:00+01:00', bst_datetime.orig_to_s, 'Rails 7 default to_s (via our shim)'
+    end
     assert_equal '01.04.2014', bst_datetime.to_formatted_s(:default), 'Rails 6 default to_s'
     assert_equal bst_datetime.to_formatted_s(:default), bst_datetime.to_s,
                  'We plan to change default to_s behaviour in a major version bump'
 
     gmt_datetime = DateTime.new(2014, 3, 1, 0, 0, 0, '+0')
-    assert_equal '2014-03-01T00:00:00+00:00', gmt_datetime.to_default_s, 'Rails 7 default to_s'
+    if gmt_datetime.respond_to?(:to_default_s) # Only defined on Rails <= 7.1
+      assert_equal '2014-03-01T00:00:00+00:00', gmt_datetime.to_default_s, 'Rails 7 default to_s'
+    else
+      assert_equal '2014-03-01T00:00:00+00:00', gmt_datetime.orig_to_s, 'Rails 7 default to_s (via our shim)'
+    end
     assert_equal '01.03.2014', gmt_datetime.to_formatted_s(:default), 'Rails 6 default to_s'
     assert_equal gmt_datetime.to_formatted_s(:default), gmt_datetime.to_s,
                  'We plan to change default to_s behaviour in a major version bump'
 
     datetime_with_hhmmss = DateTime.new(2014, 4, 1, 12, 35, 11, '+0')
-    assert_equal '2014-04-01T12:35:11+00:00', datetime_with_hhmmss.to_default_s,
-                 'Rails 7 default to_s'
+    if datetime_with_hhmmss.respond_to?(:to_default_s) # Only defined on Rails <= 7.1
+      assert_equal '2014-04-01T12:35:11+00:00', datetime_with_hhmmss.to_default_s,
+                   'Rails 7 default to_s'
+    else
+      assert_equal '2014-04-01T12:35:11+00:00', datetime_with_hhmmss.orig_to_s,
+                   'Rails 7 default to_s (via our shim)'
+    end
     assert_equal '01.04.2014 12:35', datetime_with_hhmmss.to_formatted_s(:default),
                  'Rails 6 default to_s'
     assert_equal datetime_with_hhmmss.to_formatted_s(:default), datetime_with_hhmmss.to_s,
@@ -36,7 +53,11 @@ class DateAndTimeExtensionsTest < Minitest::Test
 
   def test_time_to_s
     time = Time.new(2014, 4, 1, 12, 35, 11.5, '+01:00')
-    assert_equal '2014-04-01 12:35:11 +0100', time.to_default_s, 'Rails 7 default to_s'
+    if time.respond_to?(:to_default_s) # Only defined on Rails <= 7.1
+      assert_equal '2014-04-01 12:35:11 +0100', time.to_default_s, 'Rails 7 default to_s'
+    else
+      assert_equal '2014-04-01 12:35:11 +0100', time.orig_to_s, 'Rails 7 default to_s (via our shim)'
+    end
     assert_equal '01.04.2014 12:35', time.to_formatted_s(:default), 'Rails 6 default to_s'
     assert_equal time.to_formatted_s(:default), time.to_s,
                  'We plan to change default to_s behaviour in a major version bump'
@@ -47,8 +68,13 @@ class DateAndTimeExtensionsTest < Minitest::Test
     assert_equal 'BST', time_with_zone.zone
     # Without ndr_support extensions, we'd expect "2014-04-01 12:35:11 +0100"
     # but we have to trick the database into assuming all times are UTC to retain local time
-    assert_equal '2014-04-01 12:35:11 UTC', time_with_zone.to_default_s,
-                 'Rails 7 default to_s with our date and time formatting'
+    if time_with_zone.respond_to?(:to_default_s) # Only defined on Rails <= 7.1
+      assert_equal '2014-04-01 12:35:11 UTC', time_with_zone.to_default_s,
+                   'Rails 7 default to_s with our date and time formatting'
+    else
+      assert_equal '2014-04-01 12:35:11 +0100', time_with_zone.orig_to_s,
+                   'Rails 7 default to_s with our date and time formatting (via our shim)'
+    end
     assert_equal '01.04.2014 12:35', time_with_zone.to_formatted_s(:default), 'Rails 6 default to_s'
     assert_equal time_with_zone.to_formatted_s(:default), time_with_zone.to_s,
                  'We plan to change default to_s behaviour in a major version bump'

--- a/test/daterange_test.rb
+++ b/test/daterange_test.rb
@@ -166,11 +166,7 @@ class DaterangeTest < Minitest::Test
   def test_date_with_daylight_saving
     dr = Daterange.new(Date.new(2017, 9, 2)) # During daylight saving
     assert_equal '02.09.2017', dr.to_s
-    default_timezone = if ActiveRecord.respond_to?(:default_timezone)
-                         ActiveRecord.default_timezone
-                       else
-                         ActiveRecord::Base.default_timezone # Rails <= 6.1
-                       end
+    default_timezone = ActiveRecord.default_timezone
     return unless default_timezone == :local
 
     assert_equal Date.new(2017, 9, 2).in_time_zone.utc_offset, dr.date1.utc_offset, 'Expect consistent offset'

--- a/test/string/conversions_test.rb
+++ b/test/string/conversions_test.rb
@@ -84,11 +84,7 @@ class String::ConversionsTest < Minitest::Test
 
   test 'should convert strings to DateTime correctly' do
     assert_equal 0, '2018-01-02'.to_datetime.utc_offset
-    default_timezone = if ActiveRecord.respond_to?(:default_timezone)
-                         ActiveRecord.default_timezone
-                       else
-                         ActiveRecord::Base.default_timezone # Rails <= 6.1
-                       end
+    default_timezone = ActiveRecord.default_timezone
     return unless default_timezone == :local
 
     assert_equal Time.new(2017, 9, 2).utc_offset, '2017-09-02'.to_datetime.utc_offset, 'Expect consistent offset'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,11 +16,7 @@ NdrSupport.apply_era_date_formats!
 # require all dates to be stored in UTC in the database.
 # Thus a birth date of 1975-06-01 would be stored as 1975-05-31 23.00.00.
 # Instead, we want to store all times in local time.
-if ActiveRecord.respond_to?(:default_timezone=)
-  ActiveRecord.default_timezone = :local
-else
-  ActiveRecord::Base.default_timezone = :local # Rails <= 6.1
-end
+ActiveRecord.default_timezone = :local
 ActiveRecord::Base.time_zone_aware_attributes = false
 Time.zone = 'London'
 


### PR DESCRIPTION
Support Rails 7.1, 7.2, 8.0, Ruby 3.2, 3.3. Drop support for Rails 6.1

The linting errors are unrelated to this commit: linting errors in code adjacent to cleanups for old Rails 6.1 shims.