### PR TITLE
Fix concurrent-ruby version to 1.3.4 for older Rails versions

### DIFF
--- a/gemfiles/Gemfile.rails70
+++ b/gemfiles/Gemfile.rails70
@@ -4,3 +4,6 @@ gemspec path: '..'
 
 gem 'activerecord',  '~> 7.0.0'
 gem 'activesupport', '~> 7.0.0'
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'


### PR DESCRIPTION
This resolves test failures for Rails 7.0, caused by recently released gems.